### PR TITLE
feat: Implement UUIDs for Primary Keys

### DIFF
--- a/app/Modules/Room/Migrations/2023_07_30_103153_create_amenities_table.php
+++ b/app/Modules/Room/Migrations/2023_07_30_103153_create_amenities_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('amenities', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('uuid')->primary();
             $table->timestamps();
             $table->string('name')->unique();
             $table->text('description')->nullable();

--- a/app/Modules/Room/Migrations/2023_07_30_103837_create_room_types_table.php
+++ b/app/Modules/Room/Migrations/2023_07_30_103837_create_room_types_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('room_types', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('uuid')->primary();
             $table->timestamps();
             $table->string('name')->unique();
             $table->text('description')->nullable();

--- a/app/Modules/Room/Migrations/2023_07_30_110456_create_floors_table.php
+++ b/app/Modules/Room/Migrations/2023_07_30_110456_create_floors_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('floors', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('uuid')->primary();
             $table->timestamps();
             $table->string('name')->unique();
             $table->text('description')->nullable();

--- a/app/Modules/Room/Migrations/2023_07_30_110457_create_rooms_table.php
+++ b/app/Modules/Room/Migrations/2023_07_30_110457_create_rooms_table.php
@@ -12,16 +12,16 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('rooms', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('uuid')->primary();
             $table->timestamps();
             $table->string('name')->unique();
             $table->text('description')->nullable();
-            $table->unsignedBigInteger('room_type_id');
-            $table->foreign('room_type_id')->references('id')->on('room_types');
+            $table->uuid('room_type_id');
+            $table->foreign('room_type_id')->references('uuid')->on('room_types');
             $table->decimal('price')->default(0.0);
             $table->integer('max_pax')->default(2);
-            $table->unsignedBigInteger('floor_id');
-            $table->foreign('floor_id')->references('id')->on('floors');
+            $table->uuid('floor_id');
+            $table->foreign('floor_id')->references('uuid')->on('floors');
             $table->json('meta')->nullable();
         });
     }

--- a/app/Modules/Room/Models/Amenity.php
+++ b/app/Modules/Room/Models/Amenity.php
@@ -2,10 +2,16 @@
 
 namespace App\Modules\Room\Models;
 
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Amenity extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
+
+    protected $primaryKey = 'uuid';
+
+    protected $keyType = 'string';
+    public $incrementing = false;
 }

--- a/app/Modules/Room/Models/Floor.php
+++ b/app/Modules/Room/Models/Floor.php
@@ -2,10 +2,20 @@
 
 namespace App\Modules\Room\Models;
 
+use App\Traits\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Floor extends Model
 {
-    use HasFactory;
+  use HasFactory, HasUuids;
+
+  /**
+   *  primaryKey
+   *
+   * @var string
+   */
+  protected $primaryKey = 'uuid';
+  protected $keyType = 'string';
+  public $incrementing = false;
 }

--- a/app/Modules/Room/Models/Room.php
+++ b/app/Modules/Room/Models/Room.php
@@ -2,10 +2,21 @@
 
 namespace App\Modules\Room\Models;
 
+use App\Traits\HasUuids;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Room extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
+
+    protected $primaryKey = 'uuid';
+    protected $keyType = 'string';
+    public $incrementing = false;
+
+    public function roomType(): BelongsTo
+    {
+        return $this->belongsTo(RoomType::class, 'room_type_uuid');
+    }
 }

--- a/app/Modules/Room/Models/RoomType.php
+++ b/app/Modules/Room/Models/RoomType.php
@@ -2,12 +2,18 @@
 
 namespace App\Modules\Room\Models;
 
+use App\Traits\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class RoomType extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
 
     protected $guarded = [];
+
+    protected $primaryKey = 'uuid';
+
+    protected $keyType = 'string';
+    public $incrementing = false;
 }

--- a/app/Modules/User/Migrations/2014_10_12_000000_create_users_table.php
+++ b/app/Modules/User/Migrations/2014_10_12_000000_create_users_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('users', function (Blueprint $table) {
-            $table->uuid('id')->primary();
+            $table->uuid('uuid')->primary();
             $table->string('name');
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();

--- a/app/Modules/User/Migrations/2023_07_25_100858_create_user_profiles_table.php
+++ b/app/Modules/User/Migrations/2023_07_25_100858_create_user_profiles_table.php
@@ -12,9 +12,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('user_profiles', function (Blueprint $table) {
-            $table->id();
-            $table->uuid('user_id');
-            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->uuid('uuid')->primary();
+            $table->uuid('user_uuid');
+            $table->foreign('user_uuid')->references('uuid')->on('users')->cascadeOnDelete();
             $table->string('address_line_1')->nullable();
             $table->string('address_line_2')->nullable();
             $table->string('city')->nullable();
@@ -24,7 +24,7 @@ return new class extends Migration
             $table->boolean('is_verified')->default(false);
             $table->timestamps();
 
-            $table->index('user_id');
+            $table->index('user_uuid');
         });
     }
 

--- a/app/Modules/User/Models/User.php
+++ b/app/Modules/User/Models/User.php
@@ -14,6 +14,8 @@ class User extends Authenticatable
 {
     use HasApiTokens, HasFactory, Notifiable;
 
+    protected $primaryKey = 'uuid';
+
     /**
      * The attributes that are mass assignable.
      *
@@ -46,7 +48,6 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
-        'id' => 'string'
     ];
 
      /**
@@ -59,7 +60,7 @@ class User extends Authenticatable
         parent::boot();
 
         static::creating(function ($model) {
-            $model->{$model->getKeyName()} = (string) Str::uuid();
+            $model->uuid = (string) Str::uuid();
         });
     }
 

--- a/app/Modules/User/Models/UserProfile.php
+++ b/app/Modules/User/Models/UserProfile.php
@@ -4,10 +4,18 @@ namespace App\Modules\User\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 
 class UserProfile extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
+
+    /**
+     *  primary key is uuid
+     */
+    protected $primaryKey = 'uuid';
+    protected $keyType = 'string';
+    public $incrementing = false;
 
     protected $guarded = [];
 }

--- a/app/Modules/User/Repositories/UserProfileRepository.php
+++ b/app/Modules/User/Repositories/UserProfileRepository.php
@@ -6,6 +6,6 @@ use App\Modules\User\Models\UserProfile;
 class UserProfileRepository implements UserProfileRepositoryInterface
 {
     public function create($data){
-        return UserProfile::create($data)->only('user_id');
+        return UserProfile::create($data)->only('user_uuid');
     }
 }

--- a/app/Modules/User/Repositories/UserRepository.php
+++ b/app/Modules/User/Repositories/UserRepository.php
@@ -35,25 +35,25 @@ class UserRepository implements UserRepositoryInterface
      * @param User $user The User instance to delete.
      * @return bool True if the user is successfully deleted, false otherwise.
      */
-    public function delete(string $id): bool
+    public function delete(string $uuid): bool
     {
-        return User::destroy($id);
+        return User::destroy($uuid);
     }
 
-    public function get(string $id): User
+    public function get(string $uuid): User
     {
-        return User::find($id);
+        return User::find($uuid);
     }
 
     /**
      * Find a user by ID.
      *
-     * @param int $id The ID of the user to find.
+     * @param string $uuid The uuid of the user to find.
      * @return User|null The found User instance, or null if not found.
      */
-    public function findById(int $id): User
+    public function findById(string $uuid): User
     {
-        return User::find($id);
+        return User::find($uuid);
     }
 
     /**

--- a/app/Modules/User/Repositories/UserRepository.php
+++ b/app/Modules/User/Repositories/UserRepository.php
@@ -26,13 +26,13 @@ class UserRepository implements UserRepositoryInterface
      */
     public function update(User $user): User
     {
-        return User::where('id', $user->id)->update($user);
+        return User::where('uuid', $user->uuid)->update($user->toArray());
     }
 
     /**
      * Delete a User.
      *
-     * @param User $user The User instance to delete.
+     * @param string $uuid The uuid of the user to delete.
      * @return bool True if the user is successfully deleted, false otherwise.
      */
     public function delete(string $uuid): bool
@@ -48,7 +48,7 @@ class UserRepository implements UserRepositoryInterface
     /**
      * Find a user by ID.
      *
-     * @param string $uuid The uuid of the user to find.
+     * @param string $uuid The UUID of the user to find.
      * @return User|null The found User instance, or null if not found.
      */
     public function findById(string $uuid): User

--- a/app/Modules/User/Repositories/UserRepositoryInterface.php
+++ b/app/Modules/User/Repositories/UserRepositoryInterface.php
@@ -32,14 +32,6 @@ interface UserRepositoryInterface
     public function get(string $id): User;
 
     /**
-     * Find a user by ID.
-     *
-     * @param int $id The ID of the user to find.
-     * @return User|null The found User instance, or null if not found.
-     */
-    public function findById(int $id): User;
-
-    /**
      * Find a user by UUID.
      *
      * @param int $id The ID of the user to find.

--- a/app/Modules/User/Requests/CreateUserProfileRequest.php
+++ b/app/Modules/User/Requests/CreateUserProfileRequest.php
@@ -24,7 +24,7 @@ class CreateUserProfileRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'user_id' => 'unique:user_profiles,user_id|required|exists:users,id',
+            'user_id' => 'unique:user_profiles,user_id|required|exists:users,uuid',
             'address_line_1' => 'nullable|string|max:255',
             'address_line_2' => 'nullable|string|max:255',
             'city' => 'nullable|string|max:100',

--- a/app/Modules/User/Requests/CreateUserProfileRequest.php
+++ b/app/Modules/User/Requests/CreateUserProfileRequest.php
@@ -24,7 +24,7 @@ class CreateUserProfileRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'user_id' => 'unique:user_profiles,user_id|required|exists:users,uuid',
+            'user_uuid' => 'required|exists:users,uuid|unique:user_profiles,user_uuid',
             'address_line_1' => 'nullable|string|max:255',
             'address_line_2' => 'nullable|string|max:255',
             'city' => 'nullable|string|max:100',

--- a/app/Modules/User/Requests/DeleteUserRequest.php
+++ b/app/Modules/User/Requests/DeleteUserRequest.php
@@ -28,13 +28,13 @@ class DeleteUserRequest extends FormRequest
      *
      * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array|string>
      */
-    public function rules(): array
+    public function rules(): array  
     {
         return [
-            'id' => 'required|uuid|exists:users,id'
+            'uuid' => 'required|uuid|exists:users,uuid'
         ];
     }
-
+  
     protected function failedValidation(ValidationValidator $validator)
     {
         throw new HttpResponseException(response()->json([

--- a/app/Modules/User/Requests/ShowUserRequest.php
+++ b/app/Modules/User/Requests/ShowUserRequest.php
@@ -20,7 +20,7 @@ class ShowUserRequest extends FormRequest
     public function all($keys = null)
     {   
         $request = parent::all($keys);
-        $request['id'] = $this->route('id');
+        $request['uuid'] = $this->route('uuid');
         return $request;
     }
 
@@ -32,7 +32,7 @@ class ShowUserRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'id' => 'required|uuid|exists:users,id'
+            'uuid' => 'required|uuid|exists:users,uuid'
         ];
     }
 

--- a/app/Modules/User/Resources/UserCreatedResource.php
+++ b/app/Modules/User/Resources/UserCreatedResource.php
@@ -19,7 +19,7 @@ class UserCreatedResource extends JsonResource
         return [
             'message' => 'User created successfully.',
             'data' => [
-                'user_id' => $this->id,
+                'user_uuid' => $this->uuid,
                 'user_name' => $this->name,
                 'created_at' => $this->created_at
             ],

--- a/app/Modules/User/Resources/UserResource.php
+++ b/app/Modules/User/Resources/UserResource.php
@@ -16,7 +16,7 @@ class UserResource extends JsonResource
         return [
             'message' => 'User fetched successfully.',
             'data' => [
-                'user_id' => $this->id,
+                'user_uuid' => $this->uuid,
                 'user_name' => $this->name,
                 'created_at' => $this->created_at
             ],

--- a/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
+++ b/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('failed_jobs', function (Blueprint $table) {
-            $table->id();
+            $table->uuid('uuid')->primary();
             $table->string('uuid')->unique();
             $table->text('connection');
             $table->text('queue');

--- a/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
+++ b/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
@@ -13,7 +13,6 @@ return new class extends Migration
     {
         Schema::create('failed_jobs', function (Blueprint $table) {
             $table->uuid('uuid')->primary();
-            $table->string('uuid')->unique();
             $table->text('connection');
             $table->text('queue');
             $table->longText('payload');

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -12,8 +12,8 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
-            $table->id();
-            $table->uuid('tokenable_id');
+            $table->uuid('uuid')->primary();
+            $table->uuid('tokenable_uuid');
             $table->string('tokenable_type');
             $table->string('name');
             $table->string('token', 64)->unique();

--- a/tests/Feature/UsersTest.php
+++ b/tests/Feature/UsersTest.php
@@ -88,7 +88,7 @@ it('it cannot create a duplicate user profile', function (){
     $user = User::first();
     $uuid = $user->uuid;
     $data = [
-        'user_id' => $uuid,
+        'user_uuid' => $uuid,
         'address_line_1' => 'ad1',
         'address_line_2' => 'ad2',
         'city' => 'city',

--- a/tests/Feature/UsersTest.php
+++ b/tests/Feature/UsersTest.php
@@ -53,16 +53,17 @@ it('can create a user profile with valid data', function (){
         'email' => 'test@test2.com',
         'password' => 'test@yyyyei',
     ])->assertStatus(201);
+    $user = User::first();
+    $uuid = $user->uuid;
     $data = [
-        'user_id' => User::first()->id,
+        'user_id' => $uuid,
         'address_line_1' => 'ad1',
         'address_line_2' => 'ad2',
         'city' => 'city',
         'state' => 'state',
         'country'=> 'country',
         'is_verified' => false
-    ];
-    postUserProfile($data)->assertStatus(201);
+    ];    postUserProfile($data)->assertStatus(201);
 })->group('users');
 
 it('it cannot create a user profile with invalid id', function (){
@@ -84,16 +85,17 @@ it('it cannot create a duplicate user profile', function (){
         'email' => 'test@test2.com',
         'password' => 'test@yuiyujjhj',
     ])->assertStatus(201);
+    $user = User::first();
+    $uuid = $user->uuid;
     $data = [
-        'user_id' => User::first()->id,
+        'user_id' => $uuid,
         'address_line_1' => 'ad1',
         'address_line_2' => 'ad2',
         'city' => 'city',
         'state' => 'state',
         'country'=> 'country',
         'is_verified' => false
-    ];
-    postUserProfile($data)->assertStatus(201);
+    ];    postUserProfile($data)->assertStatus(201);
     postUserProfile($data)->assertStatus(403);
 })->group('users');
 

--- a/tests/Feature/UsersTest.php
+++ b/tests/Feature/UsersTest.php
@@ -56,7 +56,7 @@ it('can create a user profile with valid data', function (){
     $user = User::first();
     $uuid = $user->uuid;
     $data = [
-        'user_id' => $uuid,
+        'user_uuid' => $uuid,
         'address_line_1' => 'ad1',
         'address_line_2' => 'ad2',
         'city' => 'city',
@@ -68,7 +68,7 @@ it('can create a user profile with valid data', function (){
 
 it('it cannot create a user profile with invalid id', function (){
     $data = [
-        'user_id' => '01c14b35-4411-4a75-9b47-c867f1f2e720',
+        'user_uuid' => '01c14b35-4411-4a75-9b47-c867f1f2e720',
         'address_line_1' => 'ad1',
         'address_line_2' => 'ad2',
         'city' => 'city',


### PR DESCRIPTION
This commit implements the use of UUIDs as primary keys across the project. The following changes were made:

- Migrations: Updated all relevant migrations to use `uuid` type for primary keys and foreign keys.
- Models: Modified model files to use UUIDs as primary keys, including setting `$primaryKey`, `$keyType`, `$incrementing`, and using the `HasUuids` trait.
- Repositories: change the methods and the queries to work with uuid instead of id.
- Requests: Change request validations and parameters to work with uuid instead of id.

This change enhances data integrity and prepares the project for distributed environments.